### PR TITLE
feat(proxysql-agent): http server for k8s probes

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -3,7 +3,7 @@
 start_delay: 0
 
 # logging level for the app. follows log/slog conventions; defaults to INFO
-log_level: "DEBUG"
+log_level: "INFO"
 
 # proxysql admin connection configuration
 proxysql:

--- a/main.go
+++ b/main.go
@@ -44,8 +44,10 @@ func main() {
 	// so it will block the process from exiting
 	switch settings.RunMode {
 	case "core":
+		go StartAPI(psql) // start the http api
 		psql.Core()
 	case "satellite":
+		go StartAPI(psql) // start the http api
 		psql.Satellite()
 	case "dump":
 		psql.DumpData()

--- a/proxysql.go
+++ b/proxysql.go
@@ -644,3 +644,27 @@ func createCommands(pods []PodInfo) []string {
 
 	return commands
 }
+
+// startup, readiness, and liveness probe replacement. get rid of the ruby and replace it with a simple file check
+// thus function makes sure the pod is health and creates /var/lib/proxysql/healthy when things are good
+func (p *ProxySQL) RunProbes() (int, int, error) {
+	var total, online int
+
+	err := p.conn.QueryRow("SELECT COUNT(*) FROM runtime_mysql_servers").Scan(&total)
+	if err != nil {
+		return -1, -1, err
+	}
+
+	err = p.conn.QueryRow("SELECT COUNT(*) FROM runtime_mysql_servers WHERE status = 'ONLINE'").Scan(&online)
+	if err != nil {
+		return -1, -1, err
+	}
+
+	// def client_connections
+	// 	clients = `mysql -NB -e "select Client_Connections_connected from mysql_connections order by timestamp desc limit 1"`.to_i
+	//	@logger.info "Frontend clients connected to proxysql: #{clients}" if @options[:verbose]
+	//	clients
+	// end
+
+	return total, online, nil
+}

--- a/rest.go
+++ b/rest.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+)
+
+// k8s probes; we might want to make these more granular
+// curl http://localhost:8080/status
+func statusHandler(psql *ProxySQL) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		total, online, err := psql.RunProbes()
+		if err != nil {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprintf(w, `{"message": %s, "status": "unhealthy"}`, err)
+
+			slog.Error("Error in RunProbes()", slog.Any("err", err))
+		}
+
+		if online == total {
+			// all backends are up and running, we're totally healthy
+			msg := fmt.Sprintf(`{"status": "healthy", "message": "all backends online and healthy", "backends": {"total": %d, "online": %d}}`, total, online)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, msg)
+
+			slog.Debug("status check", slog.String("json", msg))
+		} else if online > 0 {
+			// some backends are offline in some way, so we're healthy but it's not great
+			msg := fmt.Sprintf(`{"status": "degraded", "message": "some backends are shunned", "backends": {"total": %d, "online": %d}}`, total, online)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, msg)
+
+			slog.Debug("status check", slog.String("json", msg))
+		} else {
+			// all backends are offline in some way
+			msg := fmt.Sprintf(`{"status": "unhealthy", "message": "no healthy backends", "backends": {"total": %d, "online": %d}}`, total, online)
+
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, msg)
+
+			slog.Debug("status check", slog.String("json", msg))
+		}
+	}
+}
+
+func StartAPI(p *ProxySQL) {
+	http.HandleFunc("/status", statusHandler(p))
+
+	// FIXME: make this configurable
+	port := ":8080"
+
+	slog.Info("Starting HTTP server", slog.String("port", port))
+	if err := http.ListenAndServe(port, nil); err != nil {
+		slog.Error("Error starting the HTTP server", slog.Any("err", err))
+
+		// goroutines can't easily return values, so let's just panic here
+		panic(err)
+	}
+}


### PR DESCRIPTION
**Description**

Added a basic http server to the agent to use for k8s probes. Right now all probes use /status, but I will refactor that apart shortly.