### PR TITLE
fix: add a configurable namespace to the core pod selector

### DIFF
--- a/configs/example_config.yaml
+++ b/configs/example_config.yaml
@@ -42,6 +42,8 @@ core:
   #           component: core  
   podselector:
     # Defaults to proxysql
+    namespace: proxysql
+    # Defaults to proxysql
     app: proxysql
     # Defaults to core
     component: core

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -29,6 +29,7 @@ type Config struct {
 	Core struct {
 		Interval    int `mapstructure:"interval"`
 		PodSelector struct {
+			Namespace string `mapstructure:"namespace"`
 			App       string `mapstructure:"app"`
 			Component string `mapstructure:"component"`
 		} `mapstructure:"podselector"`
@@ -66,6 +67,7 @@ func Configure() (*Config, error) {
 	viper.GetViper().SetDefault("proxysql.password", "")
 
 	viper.GetViper().SetDefault("core.interval", 10)
+	viper.GetViper().SetDefault("core.podselector.namespace", "proxysql")
 	viper.GetViper().SetDefault("core.podselector.app", "proxysql")
 	viper.GetViper().SetDefault("core.podselector.component", "core")
 
@@ -102,6 +104,7 @@ func Configure() (*Config, error) {
 
 	pflag.Int("core.interval", 10, "seconds to sleep in the core clustering loop")
 	pflag.String("core.checksum_file", "/tmp/pods-cs.txt", "path to the pods checksum file")
+	pflag.String("core.podselector.namespace", "proxysql", "namespace to use in the k8s pod selector label")
 	pflag.String("core.podselector.app", "proxysql", "app to use in the k8s pod selector label")
 	pflag.String("core.podselector.component", "core", "component to use in the k8s pod selector label")
 

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -24,6 +24,7 @@ proxysql:
 core:
   interval: 30
   podselector:
+    namespace: test-namespace
     app: test-application
     component: test-component
 satellite:
@@ -140,13 +141,15 @@ func TestConfigFile(t *testing.T) {
 
 func TestEnvironment(t *testing.T) {
 	t.Setenv("AGENT_START_DELAY", "500")
-	t.Setenv("AGENT_LOG_LEVEL", "WARN")
+	t.Setenv("AGENT_LOG_LEVEL", "env-WARN")
+	t.Setenv("AGENT_LOG_FORMAT", "env-text")
 	t.Setenv("AGENT_RUN_MODE", "satellite")
-	t.Setenv("AGENT_PROXYSQL_ADDRESS", "proxysql:6666")
-	t.Setenv("AGENT_PROXYSQL_USERNAME", "proxysql-user")
-	t.Setenv("AGENT_PROXYSQL_PASSWORD", "proxysql-password")
-	t.Setenv("AGENT_CORE_PODSELECTOR_APP", "proxysql-blue")
-	t.Setenv("AGENT_CORE_PODSELECTOR_COMPONENT", "proxysql-core")
+	t.Setenv("AGENT_PROXYSQL_ADDRESS", "env-proxysql:6666")
+	t.Setenv("AGENT_PROXYSQL_USERNAME", "env-proxysql-user")
+	t.Setenv("AGENT_PROXYSQL_PASSWORD", "env-proxysql-password")
+	t.Setenv("AGENT_CORE_PODSELECTOR_NAMESPACE", "env-proxysql-blue")
+	t.Setenv("AGENT_CORE_PODSELECTOR_APP", "env-proxysql-blue")
+	t.Setenv("AGENT_CORE_PODSELECTOR_COMPONENT", "env-proxysql-core")
 	t.Setenv("AGENT_SATELLITE_INTERVAL", "60")
 
 	os.Args = []string{"cmd"}
@@ -159,16 +162,17 @@ func TestEnvironment(t *testing.T) {
 	assert.NoError(t, err, "Configuration should not return an error")
 
 	assert.Equal(t, 500, envConfig.StartDelay)
-	assert.Equal(t, "WARN", envConfig.Log.Level)
-	assert.Equal(t, "text", envConfig.Log.Format)
+	assert.Equal(t, "env-WARN", envConfig.Log.Level)
+	assert.Equal(t, "env-text", envConfig.Log.Format)
 	assert.Equal(t, "satellite", envConfig.RunMode)
 
-	assert.Equal(t, "proxysql:6666", envConfig.ProxySQL.Address)
-	assert.Equal(t, "proxysql-user", envConfig.ProxySQL.Username)
-	assert.Equal(t, "proxysql-password", envConfig.ProxySQL.Password)
+	assert.Equal(t, "env-proxysql:6666", envConfig.ProxySQL.Address)
+	assert.Equal(t, "env-proxysql-user", envConfig.ProxySQL.Username)
+	assert.Equal(t, "env-proxysql-password", envConfig.ProxySQL.Password)
 
-	assert.Equal(t, "proxysql-blue", envConfig.Core.PodSelector.App)
-	assert.Equal(t, "proxysql-core", envConfig.Core.PodSelector.Component)
+	assert.Equal(t, "env-proxysql-blue", envConfig.Core.PodSelector.Namespace)
+	assert.Equal(t, "env-proxysql-blue", envConfig.Core.PodSelector.App)
+	assert.Equal(t, "env-proxysql-core", envConfig.Core.PodSelector.Component)
 
 	assert.Equal(t, 60, envConfig.Satellite.Interval)
 }

--- a/internal/proxysql/core.go
+++ b/internal/proxysql/core.go
@@ -100,6 +100,7 @@ func (p *ProxySQL) coreLoop() {
 func GetCorePods(settings *configuration.Config) ([]PodInfo, error) {
 	app := settings.Core.PodSelector.App
 	component := settings.Core.PodSelector.Component
+	namespace := settings.Core.PodSelector.Namespace
 
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -111,7 +112,7 @@ func GetCorePods(settings *configuration.Config) ([]PodInfo, error) {
 		return nil, err
 	}
 
-	pods, _ := clientset.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
+	pods, _ := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app=%s,component=%s", app, component),
 	})
 

--- a/internal/proxysql/proxysql_test.go
+++ b/internal/proxysql/proxysql_test.go
@@ -26,6 +26,7 @@ var tmpConfig = &configuration.Config{
 	Core: struct {
 		Interval    int `mapstructure:"interval"`
 		PodSelector struct {
+			Namespace string `mapstructure:"namespace"`
 			App       string `mapstructure:"app"`
 			Component string `mapstructure:"component"`
 		} "mapstructure:\"podselector\""


### PR DESCRIPTION
We have several proxysql namespaces, so being able to configure it at runtime is important.