### PR TITLE
fix: missed the a field in the csv export header

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "latest"
+		},
+		"ghcr.io/guiyomh/features/golangci-lint:0": {
+			"version": "latest"
+		},
+		"ghcr.io/marcozac/devcontainer-features/gofumpt:1": {
+			"version": "latest"
+		}
+	},
+	"remoteUser": "root"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,10 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/internal/proxysql/satellite.go
+++ b/internal/proxysql/satellite.go
@@ -145,6 +145,7 @@ func (p *ProxySQL) DumpQueryDigests(tmpdir string) (string, error) {
 	header := []string{
 		"pod_name",
 		"hostgroup",
+		"schemaname",
 		"username",
 		"digest",
 		"digest_text",


### PR DESCRIPTION
When exporting the mysql query digests, I forgot to add `schemaname` to the csv header, even though schema name is in the data. That resulted in some issues when parsing the data.

While I was doing that, I also added the go devcontainer to the project.