### PR TITLE
fix: dependabot yaml was mis-indented

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
YAML was pasted and formatted wrong, breaking dependabot workflows.