### PR TITLE
add signal handling

### DIFF
--- a/internal/proxysql/proxysql.go
+++ b/internal/proxysql/proxysql.go
@@ -194,6 +194,17 @@ func probeDraining() bool {
 	}
 }
 
+// startDraining creates the drain file to signal that the pod is draining.
+func (p *ProxySQL) startDraining() {
+	drainFile := "/var/lib/proxysql/draining"
+	slog.Info("Creating drain file to signal draining state", slog.String("path", drainFile))
+
+	_, err := os.Create(drainFile)
+	if err != nil {
+		slog.Error("Error creating drainFile", slog.String("path", drainFile), slog.Any("err", err))
+	}
+}
+
 func (p *ProxySQL) probeBackends() (int /* backends total */, int /* backends online */, error) {
 	var total, online int
 


### PR DESCRIPTION
  Signal Handling:
  - SIGTERM/SIGINT captured in main.go and propagated via context cancellation
  - Both core and satellite modes handle graceful shutdown on signal receipt

  Readiness Integration:
  - Signal immediately creates /var/lib/proxysql/draining file
  - Readiness endpoint fails (503) as soon as drain file exists
  - Kubernetes stops routing traffic before shutdown begins

  Satellite Mode:
  - Calls preStopHandler logic on signal: drains connections, pauses ProxySQL, waits for clients to disconnect
  - Ensures zero-downtime shutdown for active database connections

  Core Mode:
  - Creates drain file and cleanly stops Kubernetes informer on signal