### PR TITLE
fix shutdown race conditions and simplify graceful shutdown process

### DIFF
--- a/cmd/proxysql-agent/main.go
+++ b/cmd/proxysql-agent/main.go
@@ -69,10 +69,12 @@ func main() {
 	// so it will block the process from exiting
 	switch settings.RunMode {
 	case "core":
-		go restapi.StartAPI(psql) // start the http api
+		server := restapi.StartAPI(psql) // start the http api
+		psql.SetHTTPServer(server)
 		psql.Core(ctx)
 	case "satellite":
-		go restapi.StartAPI(psql) // start the http api
+		server := restapi.StartAPI(psql) // start the http api
+		psql.SetHTTPServer(server)
 		psql.Satellite(ctx)
 	case "dump":
 		psql.DumpData()

--- a/internal/proxysql/core_test.go
+++ b/internal/proxysql/core_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -74,7 +75,15 @@ func TestPodUpdated(t *testing.T) {
 
 			mock.MatchExpectationsInOrder(true)
 
-			p := &ProxySQL{nil, db, newTestConfig()}
+			p := &ProxySQL{
+				clientset:    nil,
+				conn:         db,
+				settings:     newTestConfig(),
+				shutdownOnce: sync.Once{},
+				shuttingDown: false,
+				shutdownMu:   sync.RWMutex{},
+				httpServer:   nil,
+			}
 
 			oldpod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -171,7 +180,15 @@ func TestPodAdded(t *testing.T) {
 
 			mock.MatchExpectationsInOrder(true)
 
-			p := &ProxySQL{nil, db, newTestConfig()}
+			p := &ProxySQL{
+				clientset:    nil,
+				conn:         db,
+				settings:     newTestConfig(),
+				shutdownOnce: sync.Once{},
+				shuttingDown: false,
+				shutdownMu:   sync.RWMutex{},
+				httpServer:   nil,
+			}
 
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -275,7 +292,15 @@ func TestAddPodToCluster(t *testing.T) {
 
 			mock.MatchExpectationsInOrder(true)
 
-			p := &ProxySQL{nil, db, newTestConfig()}
+			p := &ProxySQL{
+				clientset:    nil,
+				conn:         db,
+				settings:     newTestConfig(),
+				shutdownOnce: sync.Once{},
+				shuttingDown: false,
+				shutdownMu:   sync.RWMutex{},
+				httpServer:   nil,
+			}
 
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -377,7 +402,15 @@ func TestRemovePodFromCluster(t *testing.T) {
 
 			mock.MatchExpectationsInOrder(true)
 
-			p := &ProxySQL{nil, db, newTestConfig()}
+			p := &ProxySQL{
+				clientset:    nil,
+				conn:         db,
+				settings:     newTestConfig(),
+				shutdownOnce: sync.Once{},
+				shuttingDown: false,
+				shutdownMu:   sync.RWMutex{},
+				httpServer:   nil,
+			}
 
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/proxysql/proxysql_test.go
+++ b/internal/proxysql/proxysql_test.go
@@ -3,6 +3,7 @@ package proxysql
 import (
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/persona-id/proxysql-agent/internal/configuration"
@@ -69,7 +70,15 @@ func TestPing(t *testing.T) {
 	}
 	defer db.Close()
 
-	proxy := &ProxySQL{nil, db, newTestConfig()}
+	proxy := &ProxySQL{
+		clientset:    nil,
+		conn:         db,
+		settings:     newTestConfig(),
+		shutdownOnce: sync.Once{},
+		shuttingDown: false,
+		shutdownMu:   sync.RWMutex{},
+		httpServer:   nil,
+	}
 
 	if err = proxy.Ping(); err != nil {
 		t.Errorf("Ping() returned an error: %v", err)
@@ -123,7 +132,15 @@ func TestGetBackends(t *testing.T) {
 			}
 			defer db.Close()
 
-			proxy := &ProxySQL{nil, db, newTestConfig()}
+			proxy := &ProxySQL{
+		clientset:    nil,
+		conn:         db,
+		settings:     newTestConfig(),
+		shutdownOnce: sync.Once{},
+		shuttingDown: false,
+		shutdownMu:   sync.RWMutex{},
+		httpServer:   nil,
+	}
 
 			tt.setupMock(mock)
 

--- a/internal/proxysql/satellite.go
+++ b/internal/proxysql/satellite.go
@@ -5,10 +5,8 @@ import (
 	"encoding/csv"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -28,8 +26,10 @@ func (p *ProxySQL) Satellite(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			slog.Info("Context cancelled, stopping satellite")
-			p.startDraining()
-			p.gracefulShutdown()
+			p.shutdownOnce.Do(func() {
+				p.startDraining()
+				p.gracefulShutdown()
+			})
 
 			return
 		case <-ticker.C:
@@ -61,101 +61,47 @@ func (p *ProxySQL) GetMissingCorePods() (int, error) {
 
 // gracefulShutdown performs the graceful shutdown logic for satellite mode.
 func (p *ProxySQL) gracefulShutdown() {
-	// FIXME: make these configurable
-	shutdownDelay := 120
-	hasCSP := false
+	slog.Info("Starting graceful shutdown process")
 
-	slog.Info("Starting graceful shutdown process", slog.Int("shutdownDelay", shutdownDelay))
-
-	// the settings in the proxysql variables are all in ms, so convert shutdownDelay over to MS
-	timeouts := shutdownDelay * int(time.Millisecond)
-
-	// disable new connections
-	commands := []string{
-		fmt.Sprintf("UPDATE global_variables SET variable_value = %d WHERE variable_name in ('mysql-connection_max_age_ms', 'mysql-max_transaction_idle_time', 'mysql-max_transaction_time')", timeouts),
-		"UPDATE global_variables SET variable_value = 1 WHERE variable_name = 'mysql-wait_timeout'",
-		"LOAD MYSQL VARIABLES TO RUNTIME",
-		"PROXYSQL PAUSE;",
-	}
-
-	for _, command := range commands {
-		_, err := p.conn.Exec(command)
+	// Step 1: Pause ProxySQL to stop accepting new database connections
+	// (HTTP server continues serving shutdown responses)
+	if p.conn != nil {
+		_, err := p.conn.Exec("PROXYSQL PAUSE;")
 		if err != nil {
-			slog.Error("Command failed", slog.String("commands", command), slog.Any("error", err))
+			slog.Error("Failed to pause ProxySQL", slog.Any("error", err))
+		} else {
+			slog.Info("ProxySQL paused successfully")
+		}
+		p.conn.Close()
+		p.conn = nil
+	}
+
+	// Step 2: Wait for existing connections to drain (reasonable fixed time)
+	drainTime := 30 * time.Second
+	slog.Info("Waiting for connections to drain", slog.Duration("waitTime", drainTime))
+	time.Sleep(drainTime)
+
+	// Step 3: Stop HTTP server after connections have drained
+	if p.httpServer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		slog.Info("Shutting down HTTP server")
+		if err := p.httpServer.Shutdown(ctx); err != nil {
+			slog.Error("Error shutting down HTTP server", slog.Any("err", err))
 		}
 	}
 
-	slog.Info("Pre-stop commands ran", slog.String("commands", strings.Join(commands, "; ")))
-
-	for {
-		if p.safeToTerminate() {
-			slog.Info("No connected clients remaining, proceeding with shutdown")
-			break
-		}
-
-		time.Sleep(10 * time.Second)
-	}
-
-	// issue the PROXYSQL KILL command
-	_, err := p.conn.Exec("PROXYSQL KILL")
-	if err != nil {
-		slog.Error("KILL command failed", slog.String("commands", "PROXYSQL KILL"), slog.Any("error", err))
-	}
-
-	// kill cloud-sql-proxy (CSP) if it exists
-	if hasCSP {
-		err = p.killCSP()
-		if err != nil {
-			slog.Error("Failed to kill CSP", slog.Any("error", err))
-		}
-	}
-
-	time.Sleep(10 * time.Second)
-
+	slog.Info("Graceful shutdown completed")
 	os.Exit(0)
 }
 
 // PreStopShutdown performs the complete graceful shutdown logic for HTTP handler.
 func (p *ProxySQL) PreStopShutdown() {
-	p.startDraining()
-	p.gracefulShutdown()
-}
-
-// safeToTerminate checks if it is safe to terminate the ProxySQL instance.
-// It returns true if there are no connected clients, otherwise it returns false.
-func (p *ProxySQL) safeToTerminate() bool {
-	// check for connected clients, and when it hits 0 return true
-	clients, err := p.ProbeClients()
-	if err != nil {
-		slog.Error("Error in probeClients()", slog.Any("err", err))
-	}
-
-	if clients > 0 {
-		slog.Info("Clients connected", slog.Int("clients", clients))
-	}
-
-	// maybe we should also return true if a specified amount of time has passed, in order to not let one rogue transaction hold us up.
-	return clients == 0
-}
-
-// killCSP kills cloud-sql-proxy (CSP) if it is running; this should be optional and configurable,
-// or moved into a plugin down the road.
-func (p *ProxySQL) killCSP() error {
-	// Make an HTTP request to localhost:9091/quitquitquit
-	resp, err := http.Get("http://localhost:9091/quitquitquit")
-	if err != nil {
-		return fmt.Errorf("failed to make HTTP request to CSP: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Check the response status
-	if resp.StatusCode == http.StatusOK {
-		slog.Info("Killed CSP")
-	} else {
-		slog.Warn("HTTP request to CSP failed", slog.String("status", resp.Status))
-	}
-
-	return nil
+	p.shutdownOnce.Do(func() {
+		p.startDraining()
+		p.gracefulShutdown()
+	})
 }
 
 func (p *ProxySQL) SatelliteResync() error {

--- a/internal/proxysql/satellite_test.go
+++ b/internal/proxysql/satellite_test.go
@@ -3,6 +3,7 @@ package proxysql
 import (
 	"errors"
 	"regexp"
+	"sync"
 	"testing"
 
 	"gopkg.in/DATA-DOG/go-sqlmock.v2"
@@ -43,7 +44,15 @@ func TestGetMissingCorePods(t *testing.T) {
 			}
 			defer db.Close()
 
-			proxy := &ProxySQL{nil, db, newTestConfig()}
+			proxy := &ProxySQL{
+			clientset:    nil,
+			conn:         db,
+			settings:     newTestConfig(),
+			shutdownOnce: sync.Once{},
+			shuttingDown: false,
+			shutdownMu:   sync.RWMutex{},
+			httpServer:   nil,
+		}
 
 			// Setup the mock
 			tt.setupMock(mock)
@@ -88,9 +97,13 @@ func TestSatelliteResync(t *testing.T) {
 	mock.MatchExpectationsInOrder(true)
 
 	p := &ProxySQL{
-		clientset: nil,
-		conn:      db,
-		settings:  newTestConfig(),
+		clientset:    nil,
+		conn:         db,
+		settings:     newTestConfig(),
+		shutdownOnce: sync.Once{},
+		shuttingDown: false,
+		shutdownMu:   sync.RWMutex{},
+		httpServer:   nil,
 	}
 
 	query := regexp.QuoteMeta("SELECT COUNT(hostname) FROM stats_proxysql_servers_metrics WHERE last_check_ms > 30000 AND hostname != 'proxysql-core' AND Uptime_s > 0")


### PR DESCRIPTION
  - Add sync.Once to prevent duplicate shutdown sequences
  - Update health checks to return proper status during shutdown
  - Close DB connection immediately after PROXYSQL PAUSE to avoid "invalid connection" errors
  - Simplify shutdown flow: pause ProxySQL → drain 30s → shutdown HTTP server → exit
  - Remove unused helper methods and complex timeout logic
  - Ensure HTTP server stays available during connection drain period