### PR TITLE
fix shutdown race conditions and simplify graceful shutdown process

### DIFF
--- a/cmd/proxysql-agent/main.go
+++ b/cmd/proxysql-agent/main.go
@@ -69,10 +69,12 @@ func main() {
 	// so it will block the process from exiting
 	switch settings.RunMode {
 	case "core":
-		go restapi.StartAPI(psql) // start the http api
+		server := restapi.StartAPI(psql) // start the http api
+		psql.SetHTTPServer(server)
 		psql.Core(ctx)
 	case "satellite":
-		go restapi.StartAPI(psql) // start the http api
+		server := restapi.StartAPI(psql) // start the http api
+		psql.SetHTTPServer(server)
 		psql.Satellite(ctx)
 	case "dump":
 		psql.DumpData()

--- a/internal/proxysql/core_test.go
+++ b/internal/proxysql/core_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -74,7 +75,15 @@ func TestPodUpdated(t *testing.T) {
 
 			mock.MatchExpectationsInOrder(true)
 
-			p := &ProxySQL{nil, db, newTestConfig()}
+			p := &ProxySQL{
+				clientset:    nil,
+				conn:         db,
+				settings:     newTestConfig(),
+				shutdownOnce: sync.Once{},
+				shuttingDown: false,
+				shutdownMu:   sync.RWMutex{},
+				httpServer:   nil,
+			}
 
 			oldpod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -171,7 +180,15 @@ func TestPodAdded(t *testing.T) {
 
 			mock.MatchExpectationsInOrder(true)
 
-			p := &ProxySQL{nil, db, newTestConfig()}
+			p := &ProxySQL{
+				clientset:    nil,
+				conn:         db,
+				settings:     newTestConfig(),
+				shutdownOnce: sync.Once{},
+				shuttingDown: false,
+				shutdownMu:   sync.RWMutex{},
+				httpServer:   nil,
+			}
 
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -275,7 +292,15 @@ func TestAddPodToCluster(t *testing.T) {
 
 			mock.MatchExpectationsInOrder(true)
 
-			p := &ProxySQL{nil, db, newTestConfig()}
+			p := &ProxySQL{
+				clientset:    nil,
+				conn:         db,
+				settings:     newTestConfig(),
+				shutdownOnce: sync.Once{},
+				shuttingDown: false,
+				shutdownMu:   sync.RWMutex{},
+				httpServer:   nil,
+			}
 
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -377,7 +402,15 @@ func TestRemovePodFromCluster(t *testing.T) {
 
 			mock.MatchExpectationsInOrder(true)
 
-			p := &ProxySQL{nil, db, newTestConfig()}
+			p := &ProxySQL{
+				clientset:    nil,
+				conn:         db,
+				settings:     newTestConfig(),
+				shutdownOnce: sync.Once{},
+				shuttingDown: false,
+				shutdownMu:   sync.RWMutex{},
+				httpServer:   nil,
+			}
 
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/proxysql/proxysql.go
+++ b/internal/proxysql/proxysql.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
+	"sync"
 
 	"github.com/persona-id/proxysql-agent/internal/configuration"
 
@@ -15,9 +17,13 @@ import (
 )
 
 type ProxySQL struct {
-	clientset kubernetes.Interface
-	conn      *sql.DB
-	settings  *configuration.Config
+	clientset    kubernetes.Interface
+	conn         *sql.DB
+	settings     *configuration.Config
+	shutdownOnce sync.Once
+	shuttingDown bool
+	shutdownMu   sync.RWMutex
+	httpServer   *http.Server
 }
 
 func (p *ProxySQL) New(configs *configuration.Config) (*ProxySQL, error) {
@@ -40,7 +46,15 @@ func (p *ProxySQL) New(configs *configuration.Config) (*ProxySQL, error) {
 
 	slog.Info("Connected to ProxySQL admin", slog.String("Host", address))
 
-	return &ProxySQL{nil, conn, settings}, nil
+	return &ProxySQL{
+		clientset:    nil,
+		conn:         conn,
+		settings:     settings,
+		shutdownOnce: sync.Once{},
+		shuttingDown: false,
+		shutdownMu:   sync.RWMutex{},
+		httpServer:   nil,
+	}, nil
 }
 
 func (p *ProxySQL) Conn() *sql.DB {
@@ -157,6 +171,11 @@ func processResults(results ProbeResult) ProbeResult {
 }
 
 func (p *ProxySQL) ProbeClients() (int /* clients connected */, error) {
+	// If connection is closed or we're shutting down, return 0 clients
+	if p.conn == nil || p.IsShuttingDown() {
+		return 0, nil
+	}
+
 	var online sql.NullInt32
 
 	// this one doesnt appear to do what we want
@@ -194,8 +213,25 @@ func probeDraining() bool {
 	}
 }
 
+// IsShuttingDown returns true if the ProxySQL instance is in shutdown process.
+func (p *ProxySQL) IsShuttingDown() bool {
+	p.shutdownMu.RLock()
+	defer p.shutdownMu.RUnlock()
+
+	return p.shuttingDown
+}
+
+// SetHTTPServer sets the HTTP server reference for graceful shutdown.
+func (p *ProxySQL) SetHTTPServer(server *http.Server) {
+	p.httpServer = server
+}
+
 // startDraining creates the drain file to signal that the pod is draining.
 func (p *ProxySQL) startDraining() {
+	p.shutdownMu.Lock()
+	p.shuttingDown = true
+	p.shutdownMu.Unlock()
+
 	drainFile := "/var/lib/proxysql/draining"
 	slog.Info("Creating drain file to signal draining state", slog.String("path", drainFile))
 
@@ -206,6 +242,11 @@ func (p *ProxySQL) startDraining() {
 }
 
 func (p *ProxySQL) probeBackends() (int /* backends total */, int /* backends online */, error) {
+	// If connection is closed or we're shutting down, return default values
+	if p.conn == nil || p.IsShuttingDown() {
+		return 0, 0, nil
+	}
+
 	var total, online int
 
 	err := p.conn.QueryRow("SELECT COUNT(*) FROM runtime_mysql_servers").Scan(&total)

--- a/internal/proxysql/proxysql_test.go
+++ b/internal/proxysql/proxysql_test.go
@@ -3,6 +3,7 @@ package proxysql
 import (
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/persona-id/proxysql-agent/internal/configuration"
@@ -69,7 +70,15 @@ func TestPing(t *testing.T) {
 	}
 	defer db.Close()
 
-	proxy := &ProxySQL{nil, db, newTestConfig()}
+	proxy := &ProxySQL{
+		clientset:    nil,
+		conn:         db,
+		settings:     newTestConfig(),
+		shutdownOnce: sync.Once{},
+		shuttingDown: false,
+		shutdownMu:   sync.RWMutex{},
+		httpServer:   nil,
+	}
 
 	if err = proxy.Ping(); err != nil {
 		t.Errorf("Ping() returned an error: %v", err)
@@ -123,7 +132,15 @@ func TestGetBackends(t *testing.T) {
 			}
 			defer db.Close()
 
-			proxy := &ProxySQL{nil, db, newTestConfig()}
+			proxy := &ProxySQL{
+				clientset:    nil,
+				conn:         db,
+				settings:     newTestConfig(),
+				shutdownOnce: sync.Once{},
+				shuttingDown: false,
+				shutdownMu:   sync.RWMutex{},
+				httpServer:   nil,
+			}
 
 			tt.setupMock(mock)
 

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -1,7 +1,9 @@
 package restapi
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -19,6 +21,29 @@ import (
 func livenessHandler(psql *proxysql.ProxySQL) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+
+		// During shutdown, avoid running probes that might fail
+		if psql.IsShuttingDown() {
+			result := map[string]any{
+				"status":   "draining",
+				"message":  "shutting down",
+				"probe":    "liveness",
+				"draining": true,
+			}
+
+			resultJSON, err := json.Marshal(result)
+			if err != nil {
+				slog.Error("Error marshalling JSON", slog.Any("err", err))
+				w.WriteHeader(http.StatusInternalServerError)
+
+				return
+			}
+
+			w.WriteHeader(http.StatusOK) // Keep liveness OK during draining
+			fmt.Fprint(w, string(resultJSON))
+
+			return
+		}
 
 		results, err := psql.RunProbes()
 		if err != nil {
@@ -78,6 +103,29 @@ func livenessHandler(psql *proxysql.ProxySQL) http.HandlerFunc {
 func readinessHandler(psql *proxysql.ProxySQL) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+
+		// During shutdown, mark as not ready
+		if psql.IsShuttingDown() {
+			result := map[string]any{
+				"status":   "draining",
+				"message":  "shutting down",
+				"probe":    "readiness",
+				"draining": true,
+			}
+
+			resultJSON, err := json.Marshal(result)
+			if err != nil {
+				slog.Error("Error marshalling JSON", slog.Any("err", err))
+				w.WriteHeader(http.StatusInternalServerError)
+
+				return
+			}
+
+			w.WriteHeader(http.StatusServiceUnavailable) // Not ready during shutdown
+			fmt.Fprint(w, string(resultJSON))
+
+			return
+		}
 
 		results, err := psql.RunProbes()
 		if err != nil {
@@ -141,19 +189,19 @@ func startupHandler(psql *proxysql.ProxySQL) http.HandlerFunc {
 }
 
 func preStopHandler(psql *proxysql.ProxySQL) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		// Return success response
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		psql.PreStopShutdown()
+		psql.PreStopShutdown(r.Context())
 	}
 }
 
 // StartAPI starts the HTTP server for the ProxySQL agent.
 // It registers the necessary handlers for health checks and starts listening on the specified port.
-// The function panics if there is an error starting the server.
-func StartAPI(p *proxysql.ProxySQL) {
+// Returns the server instance for graceful shutdown.
+func StartAPI(p *proxysql.ProxySQL) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz/started", startupHandler(p))
 	mux.HandleFunc("/healthz/ready", readinessHandler(p))
@@ -175,10 +223,26 @@ func StartAPI(p *proxysql.ProxySQL) {
 
 	slog.Info("Starting HTTP server", slog.String("port", port))
 
-	// disabling this semgrep rule here because it's an internal API only accessible inside the pod itself
-	// nosemgrep: go.lang.security.audit.net.use-tls.use-tls
-	if err := server.ListenAndServe(); err != nil {
-		slog.Error("Error starting the HTTP server", slog.Any("err", err))
-		panic(err)
+	go func() {
+		// disabling this semgrep rule here because it's an internal API only accessible inside the pod itself
+		// nosemgrep: go.lang.security.audit.net.use-tls.use-tls
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("Error starting the HTTP server", slog.Any("err", err))
+			panic(err)
+		}
+	}()
+
+	return server
+}
+
+// ShutdownServer gracefully shuts down the HTTP server.
+func ShutdownServer(server *http.Server) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	slog.Info("Shutting down HTTP server")
+
+	if err := server.Shutdown(ctx); err != nil {
+		slog.Error("Error shutting down HTTP server", slog.Any("err", err))
 	}
 }


### PR DESCRIPTION
  - Add sync.Once to prevent duplicate shutdown sequences
  - Update health checks to return proper status during shutdown
  - Close DB connection immediately after PROXYSQL PAUSE to avoid "invalid connection" errors
  - Simplify shutdown flow: pause ProxySQL → drain 30s → shutdown HTTP server → exit
  - Remove unused helper methods and complex timeout logic
  - Ensure HTTP server stays available during connection drain period
