### PR TITLE
chore: more goreleaser fixes

### DIFF
--- a/build/dev.Dockerfile
+++ b/build/dev.Dockerfile
@@ -33,7 +33,7 @@ RUN apk add --no-cache bash=5.2.15-r5
 
 WORKDIR /app
 
-COPY --chown=agent:agent --from=builder --chmod=700 /build/proxysql-agent /app/
+COPY --chown=agent:agent --from=builder --chmod=700 /build/proxysql-agent /app/proxysql-agent
 COPY --chown=agent:agent --from=builder --chmod=600 /build/config.yaml /app/config.yaml
 
 USER agent


### PR DESCRIPTION
- Fix Dockerfile to not overwrite the config.yaml during image creation
- Fix Dockerfile to install the proxysql-agent binary with the correct permissions