### PR TITLE
feat: add periodic reconciliation loop to clean stale proxysql_server…

### DIFF
--- a/internal/proxysql/core.go
+++ b/internal/proxysql/core.go
@@ -148,33 +148,13 @@ func (p *ProxySQL) Core(ctx context.Context) error {
 		return fmt.Errorf("failed to add event handler to pod informer: %w", err)
 	}
 
-	// Spawn a goroutine to reconcile proxysql_servers against currently-running pods.
-	// This cleans up stale entries from previous deployments that were never removed
-	// because their deletion events were missed. Retries until ProxySQL is ready.
+	// Spawn a goroutine that reconciles proxysql_servers against currently-running pods.
+	// First performs an initial reconciliation with retries (to clean up stale entries from
+	// previous deployments), then continues running periodically to catch entries that become
+	// stale after startup (e.g. during rolling deployments where old pods terminate after
+	// the initial reconciliation completes).
 	p.podWg.Go(func() { //nolint:contextcheck
-		reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), podAddedRetryTimeout)
-		defer reconcileCancel()
-
-		for {
-			if reconcileCtx.Err() != nil {
-				slog.Error("startup reconciliation timed out")
-
-				return
-			}
-
-			if p.IsShuttingDown() {
-				return
-			}
-
-			if err := p.reconcileCluster(reconcileCtx); err != nil {
-				slog.Debug("startup reconciliation failed, retrying", slog.Any("error", err))
-				time.Sleep(p.retryDelay)
-
-				continue
-			}
-
-			return
-		}
+		p.reconcileLoop(context.Background(), time.Duration(p.settings.Core.Interval)*time.Second)
 	})
 
 	// block the main go routine from exiting
@@ -194,7 +174,72 @@ const (
 
 	// podAddedRetryDelay is the wait between retries when ProxySQL is not yet ready.
 	podAddedRetryDelay = 500 * time.Millisecond
+
+	// defaultReconcileInterval is used when the configured core.interval is zero or negative.
+	defaultReconcileInterval = 10 * time.Second
 )
+
+// reconcileLoop performs an initial reconciliation with retries, then runs
+// reconcileCluster periodically at the given interval until the context is
+// cancelled or the agent begins shutting down.
+func (p *ProxySQL) reconcileLoop(ctx context.Context, interval time.Duration) {
+	// Guard against zero/negative interval which would panic in time.NewTicker.
+	if interval <= 0 {
+		interval = defaultReconcileInterval
+	}
+
+	// Phase 1: Initial reconciliation with retries (bounded timeout).
+	initCtx, initCancel := context.WithTimeout(ctx, podAddedRetryTimeout)
+
+	for {
+		if initCtx.Err() != nil {
+			slog.Error("startup reconciliation timed out")
+			initCancel()
+
+			return
+		}
+
+		if p.IsShuttingDown() {
+			initCancel()
+
+			return
+		}
+
+		if err := p.reconcileCluster(initCtx); err != nil {
+			slog.Debug("startup reconciliation failed, retrying", slog.Any("error", err))
+			time.Sleep(p.retryDelay)
+
+			continue
+		}
+
+		break
+	}
+
+	initCancel()
+
+	// Phase 2: Periodic reconciliation.
+	slog.Info("initial reconciliation complete, starting periodic reconciliation",
+		slog.Duration("interval", interval),
+	)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if p.IsShuttingDown() {
+				return
+			}
+
+			if err := p.reconcileCluster(ctx); err != nil {
+				slog.Debug("periodic reconciliation failed", slog.Any("error", err))
+			}
+		}
+	}
+}
 
 // podAdded handles bootstrapping when core pods start. It fires for all pods visible during
 // the initial informer cache sync. By handling all Running pods (not just own hostname), it covers
@@ -255,7 +300,7 @@ func (p *ProxySQL) addPodWhenReady(ctx context.Context, pod *v1.Pod) {
 				return
 			}
 
-			slog.Error("error in podAdded()", slog.String("pod", pod.Name), slog.Any("err", fmt.Errorf("failed to query proxysql_servers: %w", err)))
+			slog.Debug("error in podAdded(), retrying", slog.String("pod", pod.Name), slog.Any("err", err))
 
 			time.Sleep(p.retryDelay)
 
@@ -379,7 +424,7 @@ func (p *ProxySQL) reconcileCluster(ctx context.Context) error {
 		return nil
 	}
 
-	slog.Info("startup reconciliation: removing stale entries", slog.Int("count", len(stale)))
+	slog.Info("reconciliation: removing stale entries", slog.Int("count", len(stale)))
 
 	for _, hostname := range stale {
 		slog.Info("removing stale proxysql_servers entry", slog.String("hostname", hostname))

--- a/internal/proxysql/core_test.go
+++ b/internal/proxysql/core_test.go
@@ -875,6 +875,220 @@ func TestPodDeleted(t *testing.T) {
 	}
 }
 
+func TestReconcileLoop(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cleans stale entries on periodic tick", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("Failed to create mock: %v", err)
+		}
+
+		t.Cleanup(func() { db.Close() })
+
+		mock.MatchExpectationsInOrder(true)
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "core-0",
+				Namespace: "proxysql",
+				Labels:    map[string]string{"app": "proxysql", "component": "core"},
+			},
+			Status: v1.PodStatus{Phase: v1.PodRunning, PodIP: "10.0.0.1"},
+		}
+
+		// Round 1 (initial): no stale entries
+		mock.ExpectQuery("SELECT hostname FROM proxysql_servers").
+			WillReturnRows(sqlmock.NewRows([]string{"hostname"}).AddRow("10.0.0.1"))
+
+		// Round 2 (periodic): stale entry appears and gets cleaned
+		mock.ExpectQuery("SELECT hostname FROM proxysql_servers").
+			WillReturnRows(sqlmock.NewRows([]string{"hostname"}).
+				AddRow("10.0.0.1").
+				AddRow("10.0.0.99"))
+
+		mock.ExpectExec(`DELETE FROM proxysql_servers WHERE hostname = "10.0.0.99"`).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		expectRuntimeLoads(mock)
+
+		p := &ProxySQL{
+			clientset:     k8sfake.NewClientset(pod),
+			conn:          db,
+			settings:      newTestConfig(),
+			shutdownPhase: PhaseRunning,
+			retryDelay:    0,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		p.reconcileLoop(ctx, 10*time.Millisecond)
+
+		if mockErr := mock.ExpectationsWereMet(); mockErr != nil {
+			t.Errorf("Unfulfilled expectations: %s", mockErr)
+		}
+	})
+
+	t.Run("exits immediately when shutting down", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("Failed to create mock: %v", err)
+		}
+
+		t.Cleanup(func() { db.Close() })
+
+		mock.MatchExpectationsInOrder(true)
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "core-0",
+				Namespace: "proxysql",
+				Labels:    map[string]string{"app": "proxysql", "component": "core"},
+			},
+			Status: v1.PodStatus{Phase: v1.PodRunning, PodIP: "10.0.0.1"},
+		}
+
+		// No SQL expectations — should exit before querying
+
+		p := &ProxySQL{
+			clientset:     k8sfake.NewClientset(pod),
+			conn:          db,
+			settings:      newTestConfig(),
+			shutdownPhase: PhaseDraining,
+			retryDelay:    0,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		p.reconcileLoop(ctx, 10*time.Millisecond)
+		elapsed := time.Since(start)
+
+		if elapsed > 100*time.Millisecond {
+			t.Errorf("reconcileLoop took %v to exit during shutdown, expected quick exit", elapsed)
+		}
+
+		if mockErr := mock.ExpectationsWereMet(); mockErr != nil {
+			t.Errorf("Unfulfilled expectations: %s", mockErr)
+		}
+	})
+
+	t.Run("does not panic with zero interval", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("Failed to create mock: %v", err)
+		}
+
+		t.Cleanup(func() { db.Close() })
+
+		mock.MatchExpectationsInOrder(true)
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "core-0",
+				Namespace: "proxysql",
+				Labels:    map[string]string{"app": "proxysql", "component": "core"},
+			},
+			Status: v1.PodStatus{Phase: v1.PodRunning, PodIP: "10.0.0.1"},
+		}
+
+		// Initial reconciliation succeeds
+		mock.ExpectQuery("SELECT hostname FROM proxysql_servers").
+			WillReturnRows(sqlmock.NewRows([]string{"hostname"}).AddRow("10.0.0.1"))
+
+		p := &ProxySQL{
+			clientset:     k8sfake.NewClientset(pod),
+			conn:          db,
+			settings:      newTestConfig(),
+			shutdownPhase: PhaseRunning,
+			retryDelay:    0,
+		}
+
+		// Zero interval should not panic — the guard replaces it with a default.
+		// Cancel immediately so the periodic loop exits after initial reconciliation.
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+
+		p.reconcileLoop(ctx, 0)
+
+		if mockErr := mock.ExpectationsWereMet(); mockErr != nil {
+			t.Errorf("Unfulfilled expectations: %s", mockErr)
+		}
+	})
+
+	t.Run("retries initial reconciliation then runs periodically", func(t *testing.T) {
+		t.Parallel()
+
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("Failed to create mock: %v", err)
+		}
+
+		t.Cleanup(func() { db.Close() })
+
+		mock.MatchExpectationsInOrder(true)
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "core-0",
+				Namespace: "proxysql",
+				Labels:    map[string]string{"app": "proxysql", "component": "core"},
+			},
+			Status: v1.PodStatus{Phase: v1.PodRunning, PodIP: "10.0.0.1"},
+		}
+
+		// Initial: fail twice
+		mock.ExpectQuery("SELECT hostname FROM proxysql_servers").
+			WillReturnError(errSQLTest)
+		mock.ExpectQuery("SELECT hostname FROM proxysql_servers").
+			WillReturnError(errSQLTest)
+
+		// Initial: succeed on third attempt
+		mock.ExpectQuery("SELECT hostname FROM proxysql_servers").
+			WillReturnRows(sqlmock.NewRows([]string{"hostname"}).AddRow("10.0.0.1"))
+
+		// Periodic: stale entry cleaned
+		mock.ExpectQuery("SELECT hostname FROM proxysql_servers").
+			WillReturnRows(sqlmock.NewRows([]string{"hostname"}).
+				AddRow("10.0.0.1").
+				AddRow("10.0.0.99"))
+
+		mock.ExpectExec(`DELETE FROM proxysql_servers WHERE hostname = "10.0.0.99"`).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		expectRuntimeLoads(mock)
+
+		p := &ProxySQL{
+			clientset:     k8sfake.NewClientset(pod),
+			conn:          db,
+			settings:      newTestConfig(),
+			shutdownPhase: PhaseRunning,
+			retryDelay:    0,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		p.reconcileLoop(ctx, 10*time.Millisecond)
+
+		if mockErr := mock.ExpectationsWereMet(); mockErr != nil {
+			t.Errorf("Unfulfilled expectations: %s", mockErr)
+		}
+	})
+}
+
 // Helper function to set up common runtime load expectations.
 func expectRuntimeLoads(mock sqlmock.Sqlmock) {
 	for _, cmd := range []string{


### PR DESCRIPTION
feat: add periodic reconciliation loop to clean stale proxysql_servers entries

Replaces the one-shot startup reconciliation with a two-phase reconcileLoop that first retries initial cleanup, then runs periodically at the configured core.interval to catch entries that become stale after startup (e.g. during rolling deployments). Also downgrades a noisy podAdded error log to debug level.