### PR TITLE
Pinning Github Action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,15 +12,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: stable
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: v2.10.1
           args: --timeout=5m

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -14,24 +14,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "stable"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: stable
           cache: false


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in CI workflows to immutable full commit SHAs to prevent supply chain attacks via mutable version tags
- Preserve version tags as inline comments for readability

## Actions pinned

| Action | Tag | Commit SHA |
|--------|-----|------------|
| `actions/checkout` | v6 | `de0fac2e` |
| `actions/setup-go` | v6 | `4a360112` |
| `golangci/golangci-lint-action` | v9 | `1e7e51e7` |
| `docker/login-action` | v3 | `c94ce9fb` |
| `goreleaser/goreleaser-action` | v7 | `ec59f474` |

## Test plan

- [ ] Verify lint workflow runs successfully on PRs
- [ ] Verify test workflow runs successfully on PRs
- [ ] Verify release workflow runs on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)