### PR TITLE
Always load proxysql configs from the config file when reconciling core pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 See the [releases](https://github.com/persona-id/proxysql-agent/releases) page for full details.
 
+## Unreleased
+
+- Core reconciliation now reloads admin variables, mysql variables, mysql servers, mysql users, and mysql query rules from the config file layer (`LOAD ... FROM CONFIG`) before loading them to runtime. This makes the on-disk config file the source of truth on every reconcile and prevents drift from ad-hoc changes to the in-memory tables. `proxysql_servers` is intentionally not reloaded from config because the agent manages cluster membership dynamically.
+
 ## 1.1.7 - 08/26/2025
 
 - Add catching SIGUSR1 and SIGUSR2; the former prints some stats to the log, the latter is NYI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ See the [releases](https://github.com/persona-id/proxysql-agent/releases) page f
 
 ## Unreleased
 
-- Core reconciliation now reloads admin variables, mysql variables, mysql servers, mysql users, and mysql query rules from the config file layer (`LOAD ... FROM CONFIG`) before loading them to runtime. This makes the on-disk config file the source of truth on every reconcile and prevents drift from ad-hoc changes to the in-memory tables. `proxysql_servers` is intentionally not reloaded from config because the agent manages cluster membership dynamically.
+- Core reconciliation now reloads admin variables, mysql variables, mysql servers, mysql users, and mysql query rules from the config file layer (`LOAD ... FROM CONFIG`) before loading them to runtime. This makes the on-disk config file the source of truth on every reconcile of a core pod event and prevents drift from ad-hoc changes to the in-memory tables. `proxysql_servers` is intentionally not reloaded from config because the agent manages cluster membership dynamically. Satellite pod events retain the previous behavior of only promoting the in-memory configuration to runtime (no `FROM CONFIG` reload), so they continue to receive configuration from the core cluster without re-applying the local config file.
 
 ## 1.1.7 - 08/26/2025
 

--- a/internal/proxysql/core.go
+++ b/internal/proxysql/core.go
@@ -434,22 +434,41 @@ func (p *ProxySQL) reconcileCluster(ctx context.Context) error {
 		}
 	}
 
-	commands := []string{
-		"LOAD PROXYSQL SERVERS TO RUNTIME",
-		"LOAD ADMIN VARIABLES TO RUNTIME",
-		"LOAD MYSQL VARIABLES TO RUNTIME",
-		"LOAD MYSQL SERVERS TO RUNTIME",
-		"LOAD MYSQL USERS TO RUNTIME",
-		"LOAD MYSQL QUERY RULES TO RUNTIME",
-	}
-
-	for _, cmd := range commands {
+	for _, cmd := range reconcileLoadCommands() {
 		if _, err := p.conn.ExecContext(ctx, cmd); err != nil {
 			return fmt.Errorf("failed to execute %q: %w", cmd, err)
 		}
 	}
 
 	return nil
+}
+
+// reconcileLoadCommands returns the sequence of ProxySQL admin commands used to
+// synchronise the runtime configuration during pod reconciliation.
+//
+// For every configuration area other than proxysql_servers we reload from the
+// config file layer before loading to runtime. This makes the on-disk config
+// file the source of truth for admin variables, mysql variables, mysql
+// servers, mysql users and mysql query rules on every reconcile, and prevents
+// drift from ad-hoc changes that may have been made to the in-memory tables.
+//
+// proxysql_servers is intentionally not reloaded from the config file because
+// the agent manages cluster membership dynamically (adding and removing core
+// pods from the table); reloading from config would clobber those changes.
+func reconcileLoadCommands() []string {
+	return []string{
+		"LOAD PROXYSQL SERVERS TO RUNTIME",
+		"LOAD ADMIN VARIABLES FROM CONFIG",
+		"LOAD ADMIN VARIABLES TO RUNTIME",
+		"LOAD MYSQL VARIABLES FROM CONFIG",
+		"LOAD MYSQL VARIABLES TO RUNTIME",
+		"LOAD MYSQL SERVERS FROM CONFIG",
+		"LOAD MYSQL SERVERS TO RUNTIME",
+		"LOAD MYSQL USERS FROM CONFIG",
+		"LOAD MYSQL USERS TO RUNTIME",
+		"LOAD MYSQL QUERY RULES FROM CONFIG",
+		"LOAD MYSQL QUERY RULES TO RUNTIME",
+	}
 }
 
 // podDeleted handles pod deletion events from the informer. It removes the pod from
@@ -508,14 +527,7 @@ func (p *ProxySQL) addPodToCluster(ctx context.Context, pod *v1.Pod) error {
 		commands = append(commands, fmt.Sprintf("INSERT INTO proxysql_servers VALUES (%q, %d, 0, %q)", pod.Status.PodIP, port, pod.Name))
 	}
 
-	commands = append(commands,
-		"LOAD PROXYSQL SERVERS TO RUNTIME",
-		"LOAD ADMIN VARIABLES TO RUNTIME",
-		"LOAD MYSQL VARIABLES TO RUNTIME",
-		"LOAD MYSQL SERVERS TO RUNTIME",
-		"LOAD MYSQL USERS TO RUNTIME",
-		"LOAD MYSQL QUERY RULES TO RUNTIME",
-	)
+	commands = append(commands, reconcileLoadCommands()...)
 
 	for _, command := range commands {
 		if p.IsShuttingDown() {
@@ -556,14 +568,7 @@ func (p *ProxySQL) removePodFromCluster(ctx context.Context, pod *v1.Pod) error 
 		commands = append(commands, fmt.Sprintf("DELETE FROM proxysql_servers WHERE hostname = %q", pod.Status.PodIP))
 	}
 
-	commands = append(commands,
-		"LOAD PROXYSQL SERVERS TO RUNTIME",
-		"LOAD ADMIN VARIABLES TO RUNTIME",
-		"LOAD MYSQL VARIABLES TO RUNTIME",
-		"LOAD MYSQL SERVERS TO RUNTIME",
-		"LOAD MYSQL USERS TO RUNTIME",
-		"LOAD MYSQL QUERY RULES TO RUNTIME",
-	)
+	commands = append(commands, reconcileLoadCommands()...)
 
 	for _, command := range commands {
 		if p.IsShuttingDown() {

--- a/internal/proxysql/core.go
+++ b/internal/proxysql/core.go
@@ -434,7 +434,7 @@ func (p *ProxySQL) reconcileCluster(ctx context.Context) error {
 		}
 	}
 
-	for _, cmd := range reconcileLoadCommands() {
+	for _, cmd := range coreReconcileLoadCommands() {
 		if _, err := p.conn.ExecContext(ctx, cmd); err != nil {
 			return fmt.Errorf("failed to execute %q: %w", cmd, err)
 		}
@@ -443,19 +443,25 @@ func (p *ProxySQL) reconcileCluster(ctx context.Context) error {
 	return nil
 }
 
-// reconcileLoadCommands returns the sequence of ProxySQL admin commands used to
-// synchronise the runtime configuration during pod reconciliation.
+// coreReconcileLoadCommands returns the sequence of ProxySQL admin commands used
+// to synchronise the runtime configuration when reconciling a core pod event
+// (core pod join/leave or the periodic proxysql_servers reconcile loop).
 //
 // For every configuration area other than proxysql_servers we reload from the
 // config file layer before loading to runtime. This makes the on-disk config
 // file the source of truth for admin variables, mysql variables, mysql
-// servers, mysql users and mysql query rules on every reconcile, and prevents
-// drift from ad-hoc changes that may have been made to the in-memory tables.
+// servers, mysql users and mysql query rules on every core-pod reconcile, and
+// prevents drift from ad-hoc changes that may have been made to the in-memory
+// tables.
 //
 // proxysql_servers is intentionally not reloaded from the config file because
 // the agent manages cluster membership dynamically (adding and removing core
 // pods from the table); reloading from config would clobber those changes.
-func reconcileLoadCommands() []string {
+//
+// This sequence is scoped to the core deployment only. Satellite pod events
+// continue to use satelliteLoadCommands so that satellite-driven reconciles
+// don't repeatedly re-apply the config file.
+func coreReconcileLoadCommands() []string {
 	return []string{
 		"LOAD PROXYSQL SERVERS TO RUNTIME",
 		"LOAD ADMIN VARIABLES FROM CONFIG",
@@ -469,6 +475,34 @@ func reconcileLoadCommands() []string {
 		"LOAD MYSQL QUERY RULES FROM CONFIG",
 		"LOAD MYSQL QUERY RULES TO RUNTIME",
 	}
+}
+
+// satelliteLoadCommands returns the sequence of ProxySQL admin commands run
+// when reconciling a satellite pod event. Satellite pods receive their
+// configuration from the core cluster at runtime, so we only promote whatever
+// is already in memory to runtime here — we do not reload from the config
+// file layer.
+func satelliteLoadCommands() []string {
+	return []string{
+		"LOAD PROXYSQL SERVERS TO RUNTIME",
+		"LOAD ADMIN VARIABLES TO RUNTIME",
+		"LOAD MYSQL VARIABLES TO RUNTIME",
+		"LOAD MYSQL SERVERS TO RUNTIME",
+		"LOAD MYSQL USERS TO RUNTIME",
+		"LOAD MYSQL QUERY RULES TO RUNTIME",
+	}
+}
+
+// loadCommandsForPod returns the appropriate load-command sequence for the
+// given pod. Core pod events trigger a FROM CONFIG reload of everything
+// except proxysql_servers; satellite pod events only promote memory to
+// runtime.
+func loadCommandsForPod(pod *v1.Pod) []string {
+	if pod.Labels["component"] == "core" {
+		return coreReconcileLoadCommands()
+	}
+
+	return satelliteLoadCommands()
 }
 
 // podDeleted handles pod deletion events from the informer. It removes the pod from
@@ -527,7 +561,7 @@ func (p *ProxySQL) addPodToCluster(ctx context.Context, pod *v1.Pod) error {
 		commands = append(commands, fmt.Sprintf("INSERT INTO proxysql_servers VALUES (%q, %d, 0, %q)", pod.Status.PodIP, port, pod.Name))
 	}
 
-	commands = append(commands, reconcileLoadCommands()...)
+	commands = append(commands, loadCommandsForPod(pod)...)
 
 	for _, command := range commands {
 		if p.IsShuttingDown() {
@@ -568,7 +602,7 @@ func (p *ProxySQL) removePodFromCluster(ctx context.Context, pod *v1.Pod) error 
 		commands = append(commands, fmt.Sprintf("DELETE FROM proxysql_servers WHERE hostname = %q", pod.Status.PodIP))
 	}
 
-	commands = append(commands, reconcileLoadCommands()...)
+	commands = append(commands, loadCommandsForPod(pod)...)
 
 	for _, command := range commands {
 		if p.IsShuttingDown() {

--- a/internal/proxysql/core_test.go
+++ b/internal/proxysql/core_test.go
@@ -57,7 +57,7 @@ func TestPodUpdated(t *testing.T) {
 					sqlmock.NewResult(0, 1),
 				)
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 		},
 		{
@@ -71,7 +71,7 @@ func TestPodUpdated(t *testing.T) {
 					sqlmock.NewResult(0, 1),
 				)
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func TestPodUpdated(t *testing.T) {
 					sqlmock.NewResult(0, 1),
 				)
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 		},
 	}
@@ -284,7 +284,7 @@ func TestAddPodWhenReady(t *testing.T) {
 					sqlmock.NewResult(0, 1),
 				)
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 		},
 		{
@@ -319,7 +319,7 @@ func TestAddPodWhenReady(t *testing.T) {
 					sqlmock.NewResult(0, 1),
 				)
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 		},
 		{
@@ -361,7 +361,7 @@ func TestAddPodWhenReady(t *testing.T) {
 					sqlmock.NewResult(0, 1),
 				)
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 		},
 		{
@@ -448,7 +448,7 @@ func TestAddPodToCluster(t *testing.T) {
 					sqlmock.NewResult(0, 1),
 				)
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 			expectFunc: func(t *testing.T, err error) {
 				t.Helper()
@@ -466,7 +466,7 @@ func TestAddPodToCluster(t *testing.T) {
 				mock.ExpectExec("DELETE FROM proxysql_servers WHERE hostname = 'proxysql-core'").
 					WillReturnResult(sqlmock.NewResult(0, 1))
 
-				expectRuntimeLoads(mock)
+				expectSatelliteRuntimeLoads(mock)
 			},
 			expectFunc: func(t *testing.T, err error) {
 				t.Helper()
@@ -541,7 +541,7 @@ func TestRemovePodFromCluster(t *testing.T) {
 					sqlmock.NewResult(0, 1),
 				)
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 			expectFunc: func(t *testing.T, err error) {
 				t.Helper()
@@ -556,7 +556,7 @@ func TestRemovePodFromCluster(t *testing.T) {
 			component: "satellite",
 			namespace: "default",
 			setupMock: func(mock sqlmock.Sqlmock) {
-				expectRuntimeLoads(mock)
+				expectSatelliteRuntimeLoads(mock)
 			},
 			expectFunc: func(t *testing.T, err error) {
 				t.Helper()
@@ -664,7 +664,7 @@ func TestReconcileCluster(t *testing.T) {
 				mock.ExpectExec(`DELETE FROM proxysql_servers WHERE hostname = "10.0.0.3"`).
 					WillReturnResult(sqlmock.NewResult(1, 1))
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 		},
 		{
@@ -705,7 +705,7 @@ func TestReconcileCluster(t *testing.T) {
 				mock.ExpectExec(`DELETE FROM proxysql_servers WHERE hostname = "10.0.0.1"`).
 					WillReturnResult(sqlmock.NewResult(1, 1))
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 		},
 		{
@@ -805,7 +805,7 @@ func TestPodDeleted(t *testing.T) {
 					`DELETE FROM proxysql_servers WHERE hostname = "10.0.0.1"`,
 				).WillReturnResult(sqlmock.NewResult(0, 1))
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 		},
 		{
@@ -819,7 +819,7 @@ func TestPodDeleted(t *testing.T) {
 				Status: v1.PodStatus{PodIP: "10.0.0.1"},
 			},
 			setupMock: func(mock sqlmock.Sqlmock) {
-				expectRuntimeLoads(mock)
+				expectSatelliteRuntimeLoads(mock)
 			},
 		},
 		{
@@ -845,7 +845,7 @@ func TestPodDeleted(t *testing.T) {
 					`DELETE FROM proxysql_servers WHERE hostname = "10.0.0.1"`,
 				).WillReturnResult(sqlmock.NewResult(0, 1))
 
-				expectRuntimeLoads(mock)
+				expectCoreReconcileLoads(mock)
 			},
 		},
 		{
@@ -912,7 +912,7 @@ func TestReconcileLoop(t *testing.T) {
 		mock.ExpectExec(`DELETE FROM proxysql_servers WHERE hostname = "10.0.0.99"`).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
-		expectRuntimeLoads(mock)
+		expectCoreReconcileLoads(mock)
 
 		p := &ProxySQL{
 			clientset:     k8sfake.NewClientset(pod),
@@ -1068,7 +1068,7 @@ func TestReconcileLoop(t *testing.T) {
 		mock.ExpectExec(`DELETE FROM proxysql_servers WHERE hostname = "10.0.0.99"`).
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
-		expectRuntimeLoads(mock)
+		expectCoreReconcileLoads(mock)
 
 		p := &ProxySQL{
 			clientset:     k8sfake.NewClientset(pod),
@@ -1089,22 +1089,35 @@ func TestReconcileLoop(t *testing.T) {
 	})
 }
 
-// Helper function to set up common runtime load expectations.
-func expectRuntimeLoads(mock sqlmock.Sqlmock) {
-	for _, cmd := range reconcileLoadCommands() {
+// expectCoreReconcileLoads registers the admin command sequence run when a
+// core pod event triggers reconciliation. Every configuration area other
+// than proxysql_servers is reloaded from the config file layer before being
+// promoted to runtime.
+func expectCoreReconcileLoads(mock sqlmock.Sqlmock) {
+	for _, cmd := range coreReconcileLoadCommands() {
 		mock.ExpectExec(cmd).WillReturnResult(sqlmock.NewResult(0, 1))
 	}
 }
 
-func TestReconcileLoadCommands(t *testing.T) {
+// expectSatelliteRuntimeLoads registers the admin command sequence run when
+// a satellite pod event triggers reconciliation. Satellite events only
+// promote the existing in-memory configuration to runtime; they do not
+// reload from the config file layer.
+func expectSatelliteRuntimeLoads(mock sqlmock.Sqlmock) {
+	for _, cmd := range satelliteLoadCommands() {
+		mock.ExpectExec(cmd).WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+}
+
+func TestCoreReconcileLoadCommands(t *testing.T) {
 	t.Parallel()
 
-	cmds := reconcileLoadCommands()
+	cmds := coreReconcileLoadCommands()
 
-	// Every configuration area that is reloaded should be reloaded from the
-	// config file layer before being loaded to runtime. proxysql_servers is
-	// intentionally excluded from the FROM CONFIG reload (see docstring on
-	// reconcileLoadCommands).
+	// Every configuration area that is reloaded on a core reconcile should be
+	// reloaded from the config file layer before being loaded to runtime.
+	// proxysql_servers is intentionally excluded from the FROM CONFIG reload
+	// (see docstring on coreReconcileLoadCommands).
 	areas := []string{
 		"ADMIN VARIABLES",
 		"MYSQL VARIABLES",
@@ -1119,29 +1132,112 @@ func TestReconcileLoadCommands(t *testing.T) {
 
 		fromIdx := indexOf(cmds, fromConfig)
 		if fromIdx < 0 {
-			t.Errorf("reconcileLoadCommands() missing %q", fromConfig)
+			t.Errorf("coreReconcileLoadCommands() missing %q", fromConfig)
 
 			continue
 		}
 
 		toIdx := indexOf(cmds, toRuntime)
 		if toIdx < 0 {
-			t.Errorf("reconcileLoadCommands() missing %q", toRuntime)
+			t.Errorf("coreReconcileLoadCommands() missing %q", toRuntime)
 
 			continue
 		}
 
 		if fromIdx >= toIdx {
-			t.Errorf("reconcileLoadCommands() has %q after %q; FROM CONFIG must precede TO RUNTIME", fromConfig, toRuntime)
+			t.Errorf("coreReconcileLoadCommands() has %q after %q; FROM CONFIG must precede TO RUNTIME", fromConfig, toRuntime)
 		}
 	}
 
 	if indexOf(cmds, "LOAD PROXYSQL SERVERS FROM CONFIG") != -1 {
-		t.Error("reconcileLoadCommands() must not reload proxysql_servers from config; agent manages it dynamically")
+		t.Error("coreReconcileLoadCommands() must not reload proxysql_servers from config; agent manages it dynamically")
 	}
 
 	if indexOf(cmds, "LOAD PROXYSQL SERVERS TO RUNTIME") < 0 {
-		t.Error("reconcileLoadCommands() missing LOAD PROXYSQL SERVERS TO RUNTIME")
+		t.Error("coreReconcileLoadCommands() missing LOAD PROXYSQL SERVERS TO RUNTIME")
+	}
+}
+
+func TestSatelliteLoadCommands(t *testing.T) {
+	t.Parallel()
+
+	cmds := satelliteLoadCommands()
+
+	// Satellite events must not trigger any FROM CONFIG reloads; they only
+	// promote in-memory configuration to runtime.
+	for _, cmd := range cmds {
+		if strings.Contains(cmd, "FROM CONFIG") {
+			t.Errorf("satelliteLoadCommands() must not contain %q", cmd)
+		}
+	}
+
+	want := []string{
+		"LOAD PROXYSQL SERVERS TO RUNTIME",
+		"LOAD ADMIN VARIABLES TO RUNTIME",
+		"LOAD MYSQL VARIABLES TO RUNTIME",
+		"LOAD MYSQL SERVERS TO RUNTIME",
+		"LOAD MYSQL USERS TO RUNTIME",
+		"LOAD MYSQL QUERY RULES TO RUNTIME",
+	}
+
+	for _, cmd := range want {
+		if indexOf(cmds, cmd) < 0 {
+			t.Errorf("satelliteLoadCommands() missing %q", cmd)
+		}
+	}
+}
+
+func TestLoadCommandsForPod(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		component string
+		wantFrom  bool
+	}{
+		{
+			name:      "core pod uses core reconcile sequence",
+			component: "core",
+			wantFrom:  true,
+		},
+		{
+			name:      "satellite pod uses satellite-only sequence",
+			component: "satellite",
+			wantFrom:  false,
+		},
+		{
+			name:      "unlabeled pod falls back to satellite-only sequence",
+			component: "",
+			wantFrom:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"component": tc.component},
+				},
+			}
+
+			cmds := loadCommandsForPod(pod)
+
+			hasFromConfig := false
+
+			for _, cmd := range cmds {
+				if strings.Contains(cmd, "FROM CONFIG") {
+					hasFromConfig = true
+
+					break
+				}
+			}
+
+			if hasFromConfig != tc.wantFrom {
+				t.Errorf("loadCommandsForPod(component=%q) FROM CONFIG present = %v, want %v", tc.component, hasFromConfig, tc.wantFrom)
+			}
+		})
 	}
 }
 

--- a/internal/proxysql/core_test.go
+++ b/internal/proxysql/core_test.go
@@ -1091,16 +1091,68 @@ func TestReconcileLoop(t *testing.T) {
 
 // Helper function to set up common runtime load expectations.
 func expectRuntimeLoads(mock sqlmock.Sqlmock) {
-	for _, cmd := range []string{
-		"LOAD PROXYSQL SERVERS TO RUNTIME",
-		"LOAD ADMIN VARIABLES TO RUNTIME",
-		"LOAD MYSQL VARIABLES TO RUNTIME",
-		"LOAD MYSQL SERVERS TO RUNTIME",
-		"LOAD MYSQL USERS TO RUNTIME",
-		"LOAD MYSQL QUERY RULES TO RUNTIME",
-	} {
+	for _, cmd := range reconcileLoadCommands() {
 		mock.ExpectExec(cmd).WillReturnResult(sqlmock.NewResult(0, 1))
 	}
+}
+
+func TestReconcileLoadCommands(t *testing.T) {
+	t.Parallel()
+
+	cmds := reconcileLoadCommands()
+
+	// Every configuration area that is reloaded should be reloaded from the
+	// config file layer before being loaded to runtime. proxysql_servers is
+	// intentionally excluded from the FROM CONFIG reload (see docstring on
+	// reconcileLoadCommands).
+	areas := []string{
+		"ADMIN VARIABLES",
+		"MYSQL VARIABLES",
+		"MYSQL SERVERS",
+		"MYSQL USERS",
+		"MYSQL QUERY RULES",
+	}
+
+	for _, area := range areas {
+		fromConfig := "LOAD " + area + " FROM CONFIG"
+		toRuntime := "LOAD " + area + " TO RUNTIME"
+
+		fromIdx := indexOf(cmds, fromConfig)
+		if fromIdx < 0 {
+			t.Errorf("reconcileLoadCommands() missing %q", fromConfig)
+
+			continue
+		}
+
+		toIdx := indexOf(cmds, toRuntime)
+		if toIdx < 0 {
+			t.Errorf("reconcileLoadCommands() missing %q", toRuntime)
+
+			continue
+		}
+
+		if fromIdx >= toIdx {
+			t.Errorf("reconcileLoadCommands() has %q after %q; FROM CONFIG must precede TO RUNTIME", fromConfig, toRuntime)
+		}
+	}
+
+	if indexOf(cmds, "LOAD PROXYSQL SERVERS FROM CONFIG") != -1 {
+		t.Error("reconcileLoadCommands() must not reload proxysql_servers from config; agent manages it dynamically")
+	}
+
+	if indexOf(cmds, "LOAD PROXYSQL SERVERS TO RUNTIME") < 0 {
+		t.Error("reconcileLoadCommands() missing LOAD PROXYSQL SERVERS TO RUNTIME")
+	}
+}
+
+func indexOf(xs []string, target string) int {
+	for i, x := range xs {
+		if x == target {
+			return i
+		}
+	}
+
+	return -1
 }
 
 // Helper function to set up common test infrastructure for pod operations.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the core reconciliation logic so that, whenever the agent reconciles a **core pod event** (core pod added / core pod removed / periodic reconcile of `proxysql_servers`), it first reloads configuration from the **config file** layer before pushing it to runtime. This makes the on-disk config file the source of truth on every core reconcile and prevents drift caused by ad-hoc changes to the in-memory tables.

**Satellite pod events keep their previous behavior.** Satellite pods receive their configuration from the core cluster at runtime, so satellite-driven reconciles must not clobber that by re-applying the local config file. They continue to only run `LOAD ... TO RUNTIME` (no `FROM CONFIG`).

### Core reconcile sequence (new)

```
LOAD PROXYSQL SERVERS TO RUNTIME
LOAD ADMIN VARIABLES FROM CONFIG
LOAD ADMIN VARIABLES TO RUNTIME
LOAD MYSQL VARIABLES FROM CONFIG
LOAD MYSQL VARIABLES TO RUNTIME
LOAD MYSQL SERVERS FROM CONFIG
LOAD MYSQL SERVERS TO RUNTIME
LOAD MYSQL USERS FROM CONFIG
LOAD MYSQL USERS TO RUNTIME
LOAD MYSQL QUERY RULES FROM CONFIG
LOAD MYSQL QUERY RULES TO RUNTIME
```

`proxysql_servers` is intentionally **not** reloaded `FROM CONFIG`; the agent manages cluster membership dynamically (inserts/deletes in that table for core pods) and a reload from config would clobber those runtime changes.

### Satellite reconcile sequence (unchanged)

```
LOAD PROXYSQL SERVERS TO RUNTIME
LOAD ADMIN VARIABLES TO RUNTIME
LOAD MYSQL VARIABLES TO RUNTIME
LOAD MYSQL SERVERS TO RUNTIME
LOAD MYSQL USERS TO RUNTIME
LOAD MYSQL QUERY RULES TO RUNTIME
```

## Changes

- `internal/proxysql/core.go`:
  - Added `coreReconcileLoadCommands()` (used by the periodic reconcile loop and by core pod join/leave events).
  - Added `satelliteLoadCommands()` (the previous `LOAD ... TO RUNTIME`-only sequence), retained for satellite pod events.
  - Added `loadCommandsForPod(pod)` which dispatches based on the pod's `component` label.
  - `addPodToCluster` and `removePodFromCluster` now use `loadCommandsForPod(pod)` so core events get the `FROM CONFIG` reload and satellite events do not.
  - `reconcileCluster` (periodic `proxysql_servers` cleanup) always uses the core sequence because it only ever operates on core pods.
- `internal/proxysql/core_test.go`:
  - Replaced the old `expectRuntimeLoads` helper with two helpers: `expectCoreReconcileLoads` and `expectSatelliteRuntimeLoads`. Each test now uses the one that matches the pod under test.
  - Added `TestCoreReconcileLoadCommands` (ordering + `proxysql_servers` exclusion).
  - Added `TestSatelliteLoadCommands` (asserts no `FROM CONFIG` entries).
  - Added `TestLoadCommandsForPod` covering core, satellite, and unlabeled pods.
- `CHANGELOG.md`: added an Unreleased entry describing the behavior change and the core/satellite split.

## Testing

- `go test ./... -race -count=1` passes.
- `go vet ./...` clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://withpersona.slack.com/archives/C0ASRPT9VEH/p1776804228394899?thread_ts=1776804228.394899&cid=C0ASRPT9VEH)

<div><a href="https://cursor.com/agents/bc-f1f678de-b39c-55dd-b806-1bac3a06e774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1f678de-b39c-55dd-b806-1bac3a06e774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

